### PR TITLE
fixed the bug, added test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PiPiMadrid"
 uuid = "768ee2b6-c705-4f61-b10f-f525213ab444"
 authors = ["Mikhail Mikhasenko <mikhail.mikhasenko@cern.ch>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/extension19.jl
+++ b/src/extension19.jl
@@ -47,7 +47,7 @@ function get_MG(s_p, coeff_K)
 end
 
 GKPY11_pure = GKPY11()
-t_conf(s; pars) = 1 / σ(s, mπ) / (cotδ0_interval1(GKPY11_pure, s; pars) - 1im)
+t_conf(s; pars) = 1 / (σ_cotδ0_interval1(GKPY11_pure, s; pars) - 1im * σ(s, mπ))
 
 ## Interval 1
 

--- a/src/s-wave.jl
+++ b/src/s-wave.jl
@@ -25,21 +25,24 @@ function s_wave_phase_shift(model::GKPY11, s::Real; pars = model.S)
 end
 
 
-function cotδ0_interval1(model::GKPY11, s::Complex; pars = model.S)
+function σ_cotδ0_interval1(model::GKPY11, s::Complex; pars = model.S)
     @unpack b_coeffs, z0 = pars
     #
     w = conformal_w(s; s0 = (2 * mK)^2)
     conf_expansion = sum(enumerate(b_coeffs)) do (i, b)
         b * w^(i - 1)
     end
-    _cotδ0_interval1 =
-        sqrt(s) / (2 * kπ(s)) * mπ^2 / (s - z0^2 / 2) *
+    _σ_cotδ0_interval1 =
+        mπ^2 / (s - z0^2 / 2) *
         (z0^2 / (mπ * sqrt(s)) + conf_expansion)
-    return _cotδ0_interval1
+    return _σ_cotδ0_interval1
 end
 
-cotδ0_interval1(model::GKPY11, s::Real; pars = model.S) =
-    cotδ0_interval1(model, s + iϵ; pars)
+σ_cotδ0_interval1(model::GKPY11, s::Real; pars = model.S) =
+    σ_cotδ0_interval1(model, s + iϵ; pars)
+
+cotδ0_interval1(model::GKPY11, s; pars) = σ_cotδ0_interval1(model, s; pars) / σ(s, mπ)
+
 
 function δ0_interval1(model::GKPY11, s::Real; pars = model.S)
     _cotδ0_interval1 = cotδ0_interval1(model, s; pars)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,8 +75,16 @@ import PiPiMadrid: t0_interval1, t0_interval2
 end
 
 @testset "Elasticity interval 1" begin
-    model = PRR19_default
+    model = PiPiMadrid.PRR19_default
     s_test = 1.1^2
-    @test PiPiMadrid.η0_interval1(model, s_test) ≈ 0.48724352714295327
+    @test PiPiMadrid.η0_interval1(model, s_test) ≈ 0.4872435393540931
     @test PiPiMadrid.t0_interval1(model, s_test) ≈ 0.18573254487071456 + 0.6870385014284162im
+end
+
+@testset "Close to threshold" begin
+    m_thr = m_thr = 2mπ + 8.627191629750897e-6
+    v = PiPiMadrid.t0_interval1(PRR19_default, m_thr^2)
+    # Imaginary part should be almost zero
+    @test imag(v) ≈ 0.00041310218334773683
+    @test real(v) ≈ 0.22823338085075165
 end


### PR DESCRIPTION
Closes #4

The PR inplements `k*cot_delta(s::Real)` dispatch instead of `cot_delta(s::Real)` dispatch that adds `i*epsilon`

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated
